### PR TITLE
Remove CommonJS emission

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "import": "./dist/index.js"
     },
     "./package.json": "./package.json",
     "./": "./"

--- a/package.json
+++ b/package.json
@@ -22,13 +22,12 @@
   "author": "talentlessguy <pilll.PL22@gmail.com>",
   "license": "MIT",
   "type": "module",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json",
     "./": "./"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,10 +4,6 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: 'dist/index.cjs',
-      format: 'cjs',
-    },
-    {
       file: 'dist/index.js',
       format: 'esm',
     },


### PR DESCRIPTION
Node.js ten is reaching EOL in March. We can safely use ESM for the future.